### PR TITLE
Add ListBuilder.Len()

### DIFF
--- a/immutable.go
+++ b/immutable.go
@@ -246,6 +246,11 @@ func (b *ListBuilder) List() *List {
 	return list
 }
 
+// Len returns the number of elements in the underlying list.
+func (b *ListBuilder) Len() int {
+	return b.list.Len()
+}
+
 // Get returns the value at the given index. Similar to slices, this method will
 // panic if index is below zero or is greater than or equal to the list size.
 func (b *ListBuilder) Get(index int) interface{} {

--- a/immutable_test.go
+++ b/immutable_test.go
@@ -274,7 +274,9 @@ func (l *TList) Slice(start, end int) {
 
 // Validate returns an error if the slice and List are different.
 func (l *TList) Validate() error {
-	if got, exp := len(l.std), l.im.Len(); got != exp {
+	if got, exp := l.im.Len(), len(l.std); got != exp {
+		return fmt.Errorf("Len()=%v, expected %d", got, exp)
+	} else if got, exp := l.builder.Len(), len(l.std); got != exp {
 		return fmt.Errorf("Len()=%v, expected %d", got, exp)
 	}
 


### PR DESCRIPTION
This commit adds a method to check the current length of a list on a `ListBuilder`. This allows the length to be checked without marking the next builder change as immutable.