### PR TITLE
List: higher level functions

### DIFF
--- a/higher_order_test.go
+++ b/higher_order_test.go
@@ -1,0 +1,48 @@
+package immutable
+
+import "testing"
+
+func TestHigherOrderList(t *testing.T) {
+	l := NewList(1, 2, 3)
+
+	t.Run("filter", func(t *testing.T) {
+		f := l.Filter(func(i int) bool { return i > 1 })
+		if f.Len() != 2 {
+			t.Fatalf("Unexpected filter result. expected 2, received %d", f.Len())
+		}
+		itr := f.Iterator()
+		_, item := itr.Next()
+		if item != 2 {
+			t.Fatalf("Unexpected filtered item. expected 2, received %d", item)
+		}
+		_, item = itr.Next()
+		if item != 3 {
+			t.Fatalf("Unexpected filtered item. expected 3, received %d", item)
+		}
+	})
+
+	t.Run("each", func(t *testing.T) {
+		j := 0
+		l.Each(func(i int) { j += i })
+		if j != 6 {
+			t.Fatalf("Unexpected Each handling: %d", j)
+		}
+	})
+
+	t.Run("map", func(t *testing.T) {
+		m := l.Map(func(i int) int { return i + 1 })
+		if m.Len() != 3 {
+			t.Fatalf("Unexpected map result. expected 3, received %d", m.Len())
+		}
+		itr := m.Iterator()
+		if _, item := itr.Next(); item != 2 {
+			t.Fatalf("Unexpected filtered item. expected 1, received %d", item)
+		}
+		if _, item := itr.Next(); item != 3 {
+			t.Fatalf("Unexpected filtered item. expected 2, received %d", item)
+		}
+		if _, item := itr.Next(); item != 4 {
+			t.Fatalf("Unexpected filtered item. expected 3, received %d", item)
+		}
+	})
+}

--- a/higher_order_test.go
+++ b/higher_order_test.go
@@ -21,16 +21,16 @@ func TestHigherOrderList(t *testing.T) {
 		}
 	})
 
-	t.Run("each", func(t *testing.T) {
+	t.Run("foreach", func(t *testing.T) {
 		j := 0
-		l.Each(func(i int) { j += i })
+		l.ForEach(func(i int, idx int) { j += i })
 		if j != 6 {
 			t.Fatalf("Unexpected Each handling: %d", j)
 		}
 	})
 
 	t.Run("map", func(t *testing.T) {
-		m := l.Map(func(i int) int { return i + 1 })
+		m := l.Map(func(i int, idx int) int { return i + 1 })
 		if m.Len() != 3 {
 			t.Fatalf("Unexpected map result. expected 3, received %d", m.Len())
 		}

--- a/immutable.go
+++ b/immutable.go
@@ -230,6 +230,39 @@ func (l *List[T]) slice(start, end int, mutable bool) *List[T] {
 	return other
 }
 
+// Filter returns a new List containing only the items matched by t
+func (l *List[T]) Filter(t func(T) bool) *List[T] {
+	n := NewList[T]()
+	itr := l.Iterator()
+	for !itr.Done() {
+		_, value := itr.Next()
+		if t(value) {
+			n.append(value, true)
+		}
+	}
+	return n
+}
+
+// Map returns a new List containing items as t(value)
+func (l *List[T]) Map(t func(T) T) *List[T] {
+	n := NewList[T]()
+	itr := l.Iterator()
+	for !itr.Done() {
+		_, value := itr.Next()
+		n.append(t(value), true)
+	}
+	return n
+}
+
+// Each performs a func for each item in a list
+func (l *List[T]) Each(t func(T)) {
+	itr := l.Iterator()
+	for !itr.Done() {
+		_, value := itr.Next()
+		t(value)
+	}
+}
+
 // Iterator returns a new iterator for this list positioned at the first index.
 func (l *List[T]) Iterator() *ListIterator[T] {
 	itr := &ListIterator[T]{list: l}

--- a/sets.go
+++ b/sets.go
@@ -69,6 +69,49 @@ func (s Set[T]) Items() []T {
 	return r
 }
 
+// Filter returns a new Set containing only the items matched by f
+func (l Set[T]) Filter(f func(T) bool) Set[T] {
+	n := NewSet(l.m.hasher)
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		if f(value) {
+			n.m.set(value, struct{}{}, true)
+		}
+	}
+	return n
+}
+
+// Map returns a new Set based on the result of the mapper for each element
+func (l Set[T]) Map(mapper func(T) T) Set[T] {
+	n := NewSet(l.m.hasher)
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		n.m.set(mapper(value), struct{}{}, true)
+	}
+	return n
+}
+
+// Reduce returns a single item, accumulated by running mapper on each element
+func (l Set[T]) Reduce(mapper func(T, T) T, acc T) T {
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		acc = mapper(value, acc)
+	}
+	return acc
+}
+
+// ForEach performs a func for each item in a list
+func (l Set[T]) ForEach(t func(T)) {
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		t(value)
+	}
+}
+
 // Iterator returns a new iterator for this set positioned at the first value.
 func (s Set[T]) Iterator() *SetIterator[T] {
 	itr := &SetIterator[T]{mi: s.m.Iterator()}
@@ -186,6 +229,49 @@ func (s SortedSet[T]) Items() []T {
 		r = append(r, v)
 	}
 	return r
+}
+
+// Filter returns a new SortedSet containing only the items matched by f
+func (l SortedSet[T]) Filter(f func(T) bool) SortedSet[T] {
+	n := NewSortedSet(l.m.comparer)
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		if f(value) {
+			n.m.set(value, struct{}{}, true)
+		}
+	}
+	return n
+}
+
+// Map returns a new SortedSet based on the result of the mapper for each element
+func (l SortedSet[T]) Map(mapper func(T) T) SortedSet[T] {
+	n := NewSortedSet(l.m.comparer)
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		n.m.set(mapper(value), struct{}{}, true)
+	}
+	return n
+}
+
+// Reduce returns a single item, accumulated by running mapper on each element
+func (l SortedSet[T]) Reduce(mapper func(T, T) T, acc T) T {
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		acc = mapper(value, acc)
+	}
+	return acc
+}
+
+// ForEach performs a func for each item in a list
+func (l SortedSet[T]) ForEach(t func(T)) {
+	itr := l.Iterator()
+	for !itr.Done() {
+		value, _ := itr.Next()
+		t(value)
+	}
 }
 
 // Iterator returns a new iterator for this set positioned at the first value.


### PR DESCRIPTION
Some https://github.com/benbjohnson/immutable/issues/27 for Lists

.Map(), .Filter(), .Each(). Seems enough for many use cases. `Each()` provides the means to approximate other HOFs like Reduce - you could use a closure on a target variable.

Note that Go generics don't allow you to introduce a new generic type in method definitions (although bare functions are allowed to declare generic types), so we're limited in what we can do in these methods. So it's not straightforward to .Map() to a list of a different type, or to .Reduce() to a different type. It's easiest to just support `Each()` and leave it to the caller to use closures.