### PR TITLE
Maps test immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Please see the internal `defaultComparer` for an example, bearing in mind that i
 
 ## Set
 
-The `Set` represents a collection of unique values. It uses a `map[T]struct{}`, so it carries over some characteristics from the built-in Go `map` type.
+The `Set` represents a collection of unique values. It uses a `Map[T]struct{}` internally.
 Values neeed to be `comparable`.
 
 Like Maps, Sets require a `Hasher` to hash keys and check for equality. There are built-in

--- a/immutable.go
+++ b/immutable.go
@@ -789,6 +789,39 @@ func (m *Map[K, V]) SetMany(entries map[K]V) *Map[K, V] {
 	return other
 }
 
+// setManySameValue is a special case for internal use by Sets
+// Sets use value type of empty struct, where the value is always the same
+func (m *Map[K, V]) setManySameValue(value V, keys ...K) *Map[K, V] {
+	other := m.clone()
+	first := true
+	for _, key := range keys {
+		if first {
+			// Set a hasher on the first value if one does not already exist.
+			if other.hasher == nil {
+				other.hasher = NewHasher(key)
+			}
+
+			// If the map is empty, initialize with a simple array node.
+			if other.root == nil {
+				other.size = 1
+				other.root = &mapArrayNode[K, V]{entries: []mapEntry[K, V]{{key: key, value: value}}}
+				first = false
+				continue
+			}
+		}
+
+		// Otherwise copy the map and delegate insertion to the root.
+		// Resized will return true if the key does not currently exist.
+		var resized bool
+		other.root = other.root.set(key, value, 0, other.hasher.Hash(key), other.hasher, !first, &resized)
+		if resized {
+			other.size++
+		}
+		first = false
+	}
+	return other
+}
+
 func (m *Map[K, V]) set(key K, value V, mutable bool) *Map[K, V] {
 	// Set a hasher on the first value if one does not already exist.
 	hasher := m.hasher
@@ -1672,6 +1705,44 @@ func (m *SortedMap[K, V]) SetMany(entries map[K]V) *SortedMap[K, V] {
 	other := m.clone()
 	first := true
 	for key, value := range entries {
+		if first {
+			if other.comparer == nil {
+				other.comparer = NewComparer(key)
+			}
+			// If no values are set then initialize with a leaf node.
+			if m.root == nil {
+				other.size = 1
+				other.root = &sortedMapLeafNode[K, V]{entries: []mapEntry[K, V]{{key: key, value: value}}}
+				first = false
+				continue
+			}
+		}
+
+		// Otherwise delegate to root node.
+		// If a split occurs then grow the tree from the root.
+		var resized bool
+		newRoot, splitNode := m.root.set(key, value, other.comparer, !first, &resized)
+		if splitNode != nil {
+			newRoot = newSortedMapBranchNode(newRoot, splitNode)
+		}
+
+		// Update root and size (if resized).
+		other.size = m.size
+		other.root = newRoot
+		if resized {
+			other.size++
+		}
+		first = false
+	}
+	return other
+}
+
+// setManySameValue is a special case for internal use by SortedSets
+// SortedSets use value type of empty struct, where the value is always the same
+func (m *SortedMap[K, V]) setManySameValue(value V, keys ...K) *SortedMap[K, V] {
+	other := m.clone()
+	first := true
+	for _, key := range keys {
 		if first {
 			if other.comparer == nil {
 				other.comparer = NewComparer(key)

--- a/immutable.go
+++ b/immutable.go
@@ -757,11 +757,36 @@ func (m *Map[K, V]) Set(key K, value V) *Map[K, V] {
 // This function will return a new map even if the updated value is the same as
 // the existing value because Map does not track value equality.
 func (m *Map[K, V]) SetMany(entries map[K]V) *Map[K, V] {
-	n := m.clone()
-	for k, v := range entries {
-		n.set(k, v, true)
+	// Set a hasher on the first value if one does not already exist.
+	hasher := m.hasher
+	other := m.clone()
+	first := true
+	for key, value := range entries {
+		if first {
+			if hasher == nil {
+				hasher = NewHasher(key)
+			}
+			other.hasher = hasher
+
+			// If the map is empty, initialize with a simple array node.
+			if other.root == nil {
+				other.size = 1
+				other.root = &mapArrayNode[K, V]{entries: []mapEntry[K, V]{{key: key, value: value}}}
+				first = false
+				continue
+			}
+		}
+
+		// Otherwise copy the map and delegate insertion to the root.
+		// Resized will return true if the key does not currently exist.
+		var resized bool
+		other.root = other.root.set(key, value, 0, hasher.Hash(key), hasher, !first, &resized)
+		if resized {
+			other.size++
+		}
+		first = false
 	}
-	return n
+	return other
 }
 
 func (m *Map[K, V]) set(key K, value V, mutable bool) *Map[K, V] {
@@ -1644,11 +1669,39 @@ func (m *SortedMap[K, V]) Set(key K, value V) *SortedMap[K, V] {
 
 // SetMany returns a map with the keys set to the new values.
 func (m *SortedMap[K, V]) SetMany(entries map[K]V) *SortedMap[K, V] {
-	n := m.clone()
-	for k, v := range entries {
-		n.set(k, v, true)
+	other := m.clone()
+	first := true
+	for key, value := range entries {
+		if first {
+			if other.comparer == nil {
+				other.comparer = NewComparer(key)
+			}
+			// If no values are set then initialize with a leaf node.
+			if m.root == nil {
+				other.size = 1
+				other.root = &sortedMapLeafNode[K, V]{entries: []mapEntry[K, V]{{key: key, value: value}}}
+				first = false
+				continue
+			}
+		}
+
+		// Otherwise delegate to root node.
+		// If a split occurs then grow the tree from the root.
+		var resized bool
+		newRoot, splitNode := m.root.set(key, value, other.comparer, !first, &resized)
+		if splitNode != nil {
+			newRoot = newSortedMapBranchNode(newRoot, splitNode)
+		}
+
+		// Update root and size (if resized).
+		other.size = m.size
+		other.root = newRoot
+		if resized {
+			other.size++
+		}
+		first = false
 	}
-	return n
+	return other
 }
 
 func (m *SortedMap[K, V]) set(key K, value V, mutable bool) *SortedMap[K, V] {

--- a/immutable_test.go
+++ b/immutable_test.go
@@ -959,6 +959,13 @@ func TestMap_Set(t *testing.T) {
 		if v, ok := m.Get(100); !ok || v != "foo" {
 			t.Fatalf("unexpected value: <%v,%v>", v, ok)
 		}
+		n := m.Set(200, "bar")
+		if v, ok := n.Get(200); !ok || v != "bar" {
+			t.Fatalf("unexpected value: <%v,%v>", v, ok)
+		}
+		if v, ok := m.Get(200); ok {
+			t.Fatalf("unexpected value for m: <%v,%v>", v, ok)
+		}
 	})
 
 	t.Run("Multi", func(t *testing.T) {
@@ -1060,6 +1067,24 @@ func TestMap_Set(t *testing.T) {
 		}
 		if err := m.Validate(); err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestMap_SetMany(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		m := NewMap[int, string](nil)
+		m = m.SetMany(map[int]string{100: "foo"})
+		if v, ok := m.Get(100); !ok || v != "foo" {
+			t.Fatalf("unexpected value: <%v,%v>", v, ok)
+		}
+		n := m.SetMany(map[int]string{200: "bar"})
+		if v, ok := n.Get(200); !ok || v != "bar" {
+			t.Fatalf("unexpected value: <%v,%v>", v, ok)
+		}
+		// check old map is unaffected
+		if v, ok := m.Get(200); ok {
+			t.Fatalf("unexpected value for m: <%v,%v>", v, ok)
 		}
 	})
 }
@@ -1875,6 +1900,24 @@ func TestSortedMap_Set(t *testing.T) {
 		}
 		if err := m.Validate(); err != nil {
 			t.Fatal(err)
+		}
+	})
+}
+
+func TestSortedMap_SetMany(t *testing.T) {
+	t.Run("Simple", func(t *testing.T) {
+		m := NewSortedMap[int, string](nil)
+		m = m.SetMany(map[int]string{100: "foo"})
+		if v, ok := m.Get(100); !ok || v != "foo" {
+			t.Fatalf("unexpected value: <%v,%v>", v, ok)
+		}
+		n := m.SetMany(map[int]string{200: "bar"})
+		if v, ok := n.Get(200); !ok || v != "bar" {
+			t.Fatalf("unexpected value: <%v,%v>", v, ok)
+		}
+		// check old map is unaffected
+		if v, ok := m.Get(200); ok {
+			t.Fatalf("unexpected value for m: <%v,%v>", v, ok)
 		}
 	})
 }

--- a/sets.go
+++ b/sets.go
@@ -33,13 +33,11 @@ func (s Set[T]) Delete(values ...T) Set[T] {
 	n := Set[T]{
 		m: s.m.clone(),
 	}
-	mutable := true
-	for i, value := range values {
+	mutable := false
+	for _, value := range values {
 		// first should be mutable. after that, reuse same new Map
 		n.m = n.m.delete(value, mutable)
-		if i == 0 {
-			mutable = false
-		}
+		mutable = true
 	}
 	return n
 }
@@ -149,12 +147,10 @@ func (s SortedSet[T]) Delete(values ...T) SortedSet[T] {
 	n := SortedSet[T]{
 		m: s.m.clone(),
 	}
-	mutable := true
-	for i, value := range values {
+	mutable := false
+	for _, value := range values {
 		n.m = n.m.delete(value, mutable)
-		if i == 0 {
-			mutable = false
-		}
+		mutable = true
 	}
 	return n
 }

--- a/sets.go
+++ b/sets.go
@@ -35,7 +35,7 @@ func (s Set[T]) Delete(values ...T) Set[T] {
 	}
 	mutable := true
 	for i, value := range values {
-		// first should be mutable. after that, reuse same new map
+		// first should be mutable. after that, reuse same new Map
 		n.m = n.m.delete(value, mutable)
 		if i == 0 {
 			mutable = false
@@ -50,7 +50,7 @@ func (s Set[T]) Has(val T) bool {
 	return ok
 }
 
-// Len returns the number of elements in the underlying map.
+// Len returns the number of elements in the underlying Map.
 func (s Set[K]) Len() int {
 	return s.m.Len()
 }
@@ -165,7 +165,7 @@ func (s SortedSet[T]) Has(val T) bool {
 	return ok
 }
 
-// Len returns the number of elements in the underlying map.
+// Len returns the number of elements in the underlying Map.
 func (s SortedSet[K]) Len() int {
 	return s.m.Len()
 }

--- a/sets_test.go
+++ b/sets_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 )
 
-func TestSetsPut(t *testing.T) {
+func TestSets_Set(t *testing.T) {
 	s := NewSet[string](nil)
 	s2 := s.Set("1").Set("1")
+	s2.Set("2") // ensure this doesn't affect the original set
 	if s.Len() != 0 {
 		t.Fatalf("Unexpected mutation of set")
 	}
@@ -31,7 +32,7 @@ func TestSetsPut(t *testing.T) {
 	}
 }
 
-func TestSetsDelete(t *testing.T) {
+func TestSets_Delete(t *testing.T) {
 	s := NewSet[string](nil)
 	s2 := s.Set("1")
 	s3 := s.Delete("1")
@@ -49,9 +50,10 @@ func TestSetsDelete(t *testing.T) {
 	}
 }
 
-func TestSortedSetsPut(t *testing.T) {
+func TestSortedSets_Set(t *testing.T) {
 	s := NewSortedSet[string](nil)
 	s2 := s.Set("1").Set("1").Set("0")
+	s2.Set("2") // ensure this doesn't affect the original set
 	if s.Len() != 0 {
 		t.Fatalf("Unexpected mutation of set")
 	}


### PR DESCRIPTION
Addresses issues raised by @BarrensZeppelin  here https://github.com/benbjohnson/immutable/issues/36 and also https://github.com/benbjohnson/immutable/issues/32#issuecomment-1375981222

@BarrensZeppelin provided a fix here too: https://github.com/benbjohnson/immutable/pull/39 (but that creates a new Map for each item being added)

The general fix is to use `mutable = false` on first item, and then `mutable = true` for the rest.

 * I fixed `Map.SetMany()` / `SortedMap.SetMany()` as above, (and added test cases which failed previously).
 * For Sets/SortedSets, I made a variant of Map.SetMany - `Map.setManySameValue()` for convenience. Tests added here too. I also fixed Set.Delete and some docs as in #39.
