### PR TITLE
feat(set): [#51] SetBuilder returns a copy of the Set

### DIFF
--- a/sets.go
+++ b/sets.go
@@ -92,6 +92,14 @@ func NewSetBuilder[T any](hasher Hasher[T]) *SetBuilder[T] {
 	return &SetBuilder[T]{s: NewSet(hasher)}
 }
 
+// ToSet returns returns the current copy of the set.
+// The builder should not be used again after the list after this call.
+func (s SetBuilder[T]) ToSet() Set[T] {
+	set := s.s
+	s.s = Set[T]{}
+	return set
+}
+
 func (s SetBuilder[T]) Set(val T) {
 	s.s.m = s.s.m.set(val, struct{}{}, true)
 }

--- a/sets_test.go
+++ b/sets_test.go
@@ -50,6 +50,30 @@ func TestSetsDelete(t *testing.T) {
 	}
 }
 
+func TestSetBuilder(t *testing.T) {
+	b := NewSetBuilder[string](nil)
+	b.Set("test3")
+	b.Set("test1")
+	b.Set("test2")
+
+	s := b.ToSet()
+	if s.Len() != 3 {
+		t.Fatalf("Set has wrong number of items")
+	}
+	if !s.Has("test1") {
+		t.Fatalf("Missing item test1")
+	}
+	if !s.Has("test2") {
+		t.Fatalf("Missing item test2")
+	}
+	if !s.Has("test3") {
+		t.Fatalf("Missing item test3")
+	}
+	if s.Has("test4") {
+		t.Fatalf("Unexpected item test4")
+	}
+}
+
 func TestSortedSetsPut(t *testing.T) {
 	s := NewSortedSet[string](nil)
 	s2 := s.Add("1").Add("1").Add("0")


### PR DESCRIPTION
`SetBuilder` should return the internal copy of the `Set`.  There is an unfortunate naming conflict between the verb `Set` to set a value in the noun `Set`.  `ToSet` seems an idiomatic-enough way to expose the underlying set.

Resolves https://github.com/benbjohnson/immutable/issues/51